### PR TITLE
ci: switch publish to npm OIDC and bump action versions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,17 +15,17 @@ jobs:
     build:
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v4
-            - uses: pnpm/action-setup@v4
+            - uses: actions/checkout@v5
+            - uses: pnpm/action-setup@v5
               with:
                   version: 9
-            - uses: actions/setup-node@v4
+            - uses: actions/setup-node@v5
               with:
-                  node-version: "20"
+                  node-version: "22"
                   cache: "pnpm"
             - run: pnpm install --frozen-lockfile
             - run: pnpm run build
-            - uses: actions/upload-artifact@v4
+            - uses: actions/upload-artifact@v5
               with:
                   name: dist
                   path: dist/
@@ -34,16 +34,16 @@ jobs:
         needs: build
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v4
-            - uses: pnpm/action-setup@v4
+            - uses: actions/checkout@v5
+            - uses: pnpm/action-setup@v5
               with:
                   version: 9
-            - uses: actions/setup-node@v4
+            - uses: actions/setup-node@v5
               with:
-                  node-version: "20"
+                  node-version: "22"
                   cache: "pnpm"
             - run: pnpm install --frozen-lockfile
-            - uses: actions/download-artifact@v4
+            - uses: actions/download-artifact@v5
               with:
                   name: dist
                   path: dist/
@@ -53,16 +53,16 @@ jobs:
         needs: build
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v4
-            - uses: pnpm/action-setup@v4
+            - uses: actions/checkout@v5
+            - uses: pnpm/action-setup@v5
               with:
                   version: 9
-            - uses: actions/setup-node@v4
+            - uses: actions/setup-node@v5
               with:
-                  node-version: "20"
+                  node-version: "22"
                   cache: "pnpm"
             - run: pnpm install --frozen-lockfile
-            - uses: actions/download-artifact@v4
+            - uses: actions/download-artifact@v5
               with:
                   name: dist
                   path: dist/
@@ -72,21 +72,22 @@ jobs:
     publish:
         needs: [test, test-e2e]
         runs-on: ubuntu-latest
+        permissions:
+            id-token: write
+            contents: read
         steps:
-            - uses: actions/checkout@v4
-            - uses: pnpm/action-setup@v4
+            - uses: actions/checkout@v5
+            - uses: pnpm/action-setup@v5
               with:
                   version: 9
-            - uses: actions/setup-node@v4
+            - uses: actions/setup-node@v5
               with:
-                  node-version: "20"
+                  node-version: "22"
                   cache: "pnpm"
                   registry-url: "https://registry.npmjs.org"
             - run: pnpm install --frozen-lockfile
-            - uses: actions/download-artifact@v4
+            - uses: actions/download-artifact@v5
               with:
                   name: dist
                   path: dist/
             - run: pnpm publish --no-git-checks --access public ${{ inputs.dry_run && '--dry-run' || '' }}
-              env:
-                  NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Trusted Publisher is configured on the @diphyx/harlemify package on npm, so the workflow can authenticate via OIDC and no long-lived NPM_TOKEN is needed.

- Add `permissions: id-token: write, contents: read` on the publish job — required to issue the OIDC token GitHub exchanges with npm.
- Drop `NODE_AUTH_TOKEN: secrets.NPM_TOKEN` from the publish step.
- Bump all actions to v5 (checkout, setup-node, upload-artifact, download-artifact, pnpm/action-setup) to clear the Node 20 runner deprecation warning.
- Bump `node-version` from 20 to 22 (Active LTS through Apr 2027).