### PR TITLE
ci: use npm CLI for OIDC publish and bump actions to Node 24

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,17 +15,17 @@ jobs:
     build:
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v5
-            - uses: pnpm/action-setup@v5
+            - uses: actions/checkout@v6
+            - uses: pnpm/action-setup@v6
               with:
                   version: 9
-            - uses: actions/setup-node@v5
+            - uses: actions/setup-node@v6
               with:
                   node-version: "22"
                   cache: "pnpm"
             - run: pnpm install --frozen-lockfile
             - run: pnpm run build
-            - uses: actions/upload-artifact@v5
+            - uses: actions/upload-artifact@v7
               with:
                   name: dist
                   path: dist/
@@ -34,16 +34,16 @@ jobs:
         needs: build
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v5
-            - uses: pnpm/action-setup@v5
+            - uses: actions/checkout@v6
+            - uses: pnpm/action-setup@v6
               with:
                   version: 9
-            - uses: actions/setup-node@v5
+            - uses: actions/setup-node@v6
               with:
                   node-version: "22"
                   cache: "pnpm"
             - run: pnpm install --frozen-lockfile
-            - uses: actions/download-artifact@v5
+            - uses: actions/download-artifact@v8
               with:
                   name: dist
                   path: dist/
@@ -53,16 +53,16 @@ jobs:
         needs: build
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v5
-            - uses: pnpm/action-setup@v5
+            - uses: actions/checkout@v6
+            - uses: pnpm/action-setup@v6
               with:
                   version: 9
-            - uses: actions/setup-node@v5
+            - uses: actions/setup-node@v6
               with:
                   node-version: "22"
                   cache: "pnpm"
             - run: pnpm install --frozen-lockfile
-            - uses: actions/download-artifact@v5
+            - uses: actions/download-artifact@v8
               with:
                   name: dist
                   path: dist/
@@ -76,18 +76,14 @@ jobs:
             id-token: write
             contents: read
         steps:
-            - uses: actions/checkout@v5
-            - uses: pnpm/action-setup@v5
-              with:
-                  version: 9
-            - uses: actions/setup-node@v5
+            - uses: actions/checkout@v6
+            - uses: actions/setup-node@v6
               with:
                   node-version: "22"
-                  cache: "pnpm"
                   registry-url: "https://registry.npmjs.org"
-            - run: pnpm install --frozen-lockfile
-            - uses: actions/download-artifact@v5
+            - run: npm install -g npm@latest
+            - uses: actions/download-artifact@v8
               with:
                   name: dist
                   path: dist/
-            - run: pnpm publish --no-git-checks --access public ${{ inputs.dry_run && '--dry-run' || '' }}
+            - run: npm publish --access public ${{ inputs.dry_run && '--dry-run' || '' }}


### PR DESCRIPTION
- Switch publish step from `pnpm publish` to `npm publish`. OIDC trusted publishing is only supported by the npm CLI, not pnpm's wrapper. Install npm@latest in the publish job to meet the
  >=11.5.1 requirement, since Node 22 ships with npm 10.
- Drop pnpm setup + install from the publish job — it doesn't need dependencies, just the built artifact and the package manifest.
- Bump all reusable actions to their latest Node 24-compatible majors to clear the Node 20 deprecation warning:
    actions/checkout         v5 → v6
    actions/setup-node       v5 → v6
    actions/upload-artifact  v5 → v7
    actions/download-artifact v5 → v8
    pnpm/action-setup        v5 → v6