### PR TITLE
ci: skip prepare script on publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -86,4 +86,4 @@ jobs:
               with:
                   name: dist
                   path: dist/
-            - run: npm publish --access public ${{ inputs.dry_run && '--dry-run' || '' }}
+            - run: npm publish --ignore-scripts --access public ${{ inputs.dry_run && '--dry-run' || '' }}


### PR DESCRIPTION
The `prepare` script in package.json runs `pnpm nuxt prepare`, which npm publish invokes as part of its pack lifecycle. The publish job no longer installs pnpm (it doesn't need to — dist comes from the build artifact), so the script fails with `pnpm: not found`.

Add `--ignore-scripts` to skip lifecycle hooks during publish. The artifact is already built and validated by the upstream jobs, so re-running prepare here is redundant anyway.